### PR TITLE
Improvements

### DIFF
--- a/templates/css/raml.styl
+++ b/templates/css/raml.styl
@@ -238,6 +238,9 @@ res(i, max)
   .no-padding
     padding 0 !important
 
+  span.or
+    font-weight bold
+
   for i in 2..10
     .s{i}
       flex i !important

--- a/templates/raml/json-schema-table.jade
+++ b/templates/raml/json-schema-table.jade
@@ -132,8 +132,7 @@ mixin propertyOneOfRow(property, level)
         .badge oneOf
       .flex-table-cell.center object
       .flex-table-cell.s2.constraints
-        .badge.badge-required Required
-        .badge.badge-required Must be one of the following objects
+        .badge.badge-required One is required in the following objects
       .flex-table-cell.s4!= helpers.marked(property.description)
 
     each oneOfProperty, i in property.oneOf

--- a/templates/raml/json-schema-table.jade
+++ b/templates/raml/json-schema-table.jade
@@ -130,7 +130,8 @@ mixin propertyOneOfRow(property, level)
     .flex-table-row(class='level-#{level}')
       .flex-table-cell.s2.property
         .badge oneOf
-      .flex-table-cell.center object
+      .flex-table-cell.center
+        .badge object
       .flex-table-cell.s2.constraints
         .badge.badge-required One is required in the following objects
       .flex-table-cell.s4!= helpers.marked(property.description)

--- a/templates/raml/json-schema-table.jade
+++ b/templates/raml/json-schema-table.jade
@@ -133,6 +133,7 @@ mixin propertyOneOfRow(property, level)
       .flex-table-cell.center object
       .flex-table-cell.s2.constraints
         .badge.badge-required Required
+        .badge.badge-required Must be one of the following objects
       .flex-table-cell.s4!= helpers.marked(property.description)
 
     each oneOfProperty, i in property.oneOf

--- a/templates/raml/json-schema-table.jade
+++ b/templates/raml/json-schema-table.jade
@@ -68,7 +68,7 @@ mixin minMaxLengthJsonConstraint(property)
 mixin enumJsonConstraint(property)
   if property.enum
     if property.enum.length === 1
-      .badge.badge-constraint == #{property.enum[0]}
+      .badge.badge-required Must be: #{property.enum[0]}
     else
       .badge.badge-constraint One of:
         each value, i in property.enum
@@ -88,7 +88,7 @@ mixin jsonSchemaConstraints(property, name, required)
   +minMaxItemsJsonConstraint(property)
 
 mixin propertyRowLeveled(property, level)
-  if property.type == 'object'
+  if property.type == 'object' || property.properties
     +properties(property, level + 1)
   else if property.type == 'array' && property.items
     +propertyRow(null, property.items, [], level + 1)
@@ -96,7 +96,11 @@ mixin propertyRowLeveled(property, level)
 mixin propertyRowContent(name, property, required, level)
   .flex-table-row(class='level-#{level}')
     if name
-      .flex-table-cell.s2.property= name
+      if property.type
+        .flex-table-cell.s2.property= name
+      else
+        .flex-table-cell.s2.property
+          .badge= name
     else
       .flex-table-cell.s2.property
         .badge #{property.type == 'array' ? 'collection' : 'item'}
@@ -121,9 +125,31 @@ mixin propertyRow(name, property, required, level)
     +propertyRowContent(name, property, required, level)
     +propertyRowLeveled(property, level)
 
+mixin propertyOneOfRow(property, level)
+  .flex-table(class='level-#{level}')
+    .flex-table-row(class='level-#{level}')
+      .flex-table-cell.s2.property
+        .badge oneOf
+      .flex-table-cell.center object
+      .flex-table-cell.s2.constraints
+        .badge.badge-required Required
+      .flex-table-cell.s4!= helpers.marked(property.description)
+
+    each oneOfProperty, i in property.oneOf
+      if i > 0
+        .flex-table(class='level-#{level + 2}')
+          .flex-table-row(class='level-#{level + 2}')
+            .flex-table-cell.center
+              span.or Or
+
+      +propertyRow('object', oneOfProperty, [], level + 1)
+
 mixin properties(schema, level)
   if schema.type == 'array'
     +propertyRow(null, schema, schema.required, level)
+
+  else if schema.oneOf
+    +propertyOneOfRow(schema, level)
 
   else
     if schema.properties
@@ -136,12 +162,12 @@ mixin properties(schema, level)
 
 mixin jsonSchemaTable(schema)
   .jsonSchemaLevel
-    if schema.properties || schema.patternProperties || schema.items
+    if schema.properties || schema.patternProperties || schema.items || schema.oneOf
       .flex-table
         .flex-table-row.no-left-border
           .flex-table-cell.center
             h2= schema.title
-            if schema.description
+            if schema.description && !schema.oneOf
               div!= helpers.marked(schema.description)
 
         .flex-table-headers
@@ -149,7 +175,5 @@ mixin jsonSchemaTable(schema)
           .flex-table-header.center Type
           .flex-table-header.s2.center JSON Schema Constraints
           .flex-table-header.s4 Description
-
-        if schema.title || schema.description
 
         +properties(schema, 0)


### PR DESCRIPTION
Allows to write that:

```
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "title": "Organization action",
  "description": "Execute an action for the organization. Only one action at a time.",
  "type": "object",
  "oneOf": [ {
    "description": "Action: Add user to an organization",
    "type": "object",
    "required": [ "type", "userId" ],
    "properties": {
      "type": {
        "description": "addUser action type",
        "type": "string",
        "enum": [
          "addUser"
        ]
      },
      "userId": {
        "description": "User id",
        "type": "integer"
      }
    }
  }, {
    "description": "Action: Remove user from an organization",
    "type": "object",
    "required": [ "type", "userId" ],
    "properties": {
      "type": {
        "description": "removeUser action type",
        "type": "string",
        "enum": [
          "removeUser"
        ]
      },
      "userId": {
        "description": "User id",
        "type": "integer"
      }
    }
  }],
  "required": [ "name" ]
}
```

Is rendered like:

```
oneOf | object | One is required in the following objects | descr 
  object | type | descr
    type | enum[string] | Required Must be: addUser | descr
    userId | integer | | descr
                                                  OR
  object | type | descr
    type | enum[string] | Required Must be: removeUser | descr
    userId | integer | | descr
```
